### PR TITLE
fix data retrieval for small polygons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Changelog
 
+## [0.1.1] - 2026-04-20
+
+- fix data extraction for polygons smaller than the pixel resolution
+
+
 ## [0.1.0] - 2026-01-01
 
 - Initial release
 - Core EII data access functions
 - Basic documentation
-
-[Unreleased]: https://github.com/landler-io/ecosystem-integrity-index/compare/v0.1.0...HEAD
-[0.1.0]: https://github.com/landler-io/ecosystem-integrity-index/releases/tag/v0.1.0

--- a/src/eii/client/retrieve.py
+++ b/src/eii/client/retrieve.py
@@ -251,12 +251,22 @@ def _reduce_area_stats(
     if stats is None:
         stats = ["mean"]
     reducer = _build_reducer(stats, percentiles)
-    return image.reduceRegion(
+    result = image.reduceRegion(
         reducer=reducer,
         geometry=geometry,
         scale=scale,
         maxPixels=1e12,
     )
+    # sub-pixel polygons have no pixel centers inside, so reduceRegion returns
+    # all nulls. Fall back to sampling at the centroid with the same reducer.
+    has_data = result.values().reduce(ee.Reducer.count())
+    centroid_result = image.reduceRegion(
+        reducer=reducer,
+        geometry=geometry.centroid(maxError=1),
+        scale=scale,
+        maxPixels=1e12,
+    )
+    return ee.Algorithms.If(has_data, result, centroid_result)
 
 
 def _format_stats(
@@ -388,7 +398,10 @@ def _download_image_to_geotiff(
     tmp_dir = Path(tempfile.mkdtemp())
     try:
         tmp_download = tmp_dir / "download"
-        with urllib.request.urlopen(url) as response, open(tmp_download, "wb") as handle:
+        with (
+            urllib.request.urlopen(url) as response,
+            open(tmp_download, "wb") as handle,
+        ):
             handle.write(response.read())
 
         if zipfile.is_zipfile(tmp_download):


### PR DESCRIPTION
## Description

extraction of values for polygons < 300m resolution failed. now we fall back to the centroid for these

## Type of Change

- [ x] Bug fix (non-breaking change which fixes an issue)

